### PR TITLE
 Fix typo error in PowerShell scripts

### DIFF
--- a/downloadphp.ps1
+++ b/downloadphp.ps1
@@ -14,7 +14,7 @@ else
 }
 if($PSVersiontable.PSVersion.Major -lt 5)
 {
-    if((Test-Path "$workdingdir\php") -eq $False)
+    if((Test-Path "$workingdir\php") -eq $False)
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         [IO.Compression.ZipFile]::ExtractToDirectory('php.zip', 'php\')

--- a/downloadpython.ps1
+++ b/downloadpython.ps1
@@ -16,7 +16,7 @@ else
 }
 if($PSVersiontable.PSVersion.Major -lt 5)
 {
-    if((Test-Path "$workdingdir\python") -eq $False)
+    if((Test-Path "$workingdir\python") -eq $False)
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         [IO.Compression.ZipFile]::ExtractToDirectory('python.zip', 'python\')


### PR DESCRIPTION
Fix typo error in PowerShell scripts that make scripts cannot run properly on Windows Server 2008 R2 or older.